### PR TITLE
se adiciono el nombre David Alejandro Galeano

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ Jorge Andrés Cerón Peñaloza
 Jesus Enrique Rodriguez mendoza
 Santiago Collantes Nieto
 Dario Steven Henao 
+* David Alejandro Galeano
 


### PR DESCRIPTION
 se adisiono el nombre David Galeano con el asterisco (*) al comienzo del nombre, para listarse